### PR TITLE
Fix eslint errors fib route

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+module.exports = function fibonacci(n: number) : number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+module.exports = function fibonacci(n :number) :number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,12 +1,12 @@
 // Endpoint for querying the fibonacci numbers
 
-const fibonacci = require("./fib");
+const fibonacci : NodeRequire = require("./fib");
 
 export default (req, res) => {
-  const { num } = req.params;
+  const { num } : { num: string } = req.params;
 
-  const fibN = fibonacci(parseInt(num));
-  let result = `fibonacci(${num}) is ${fibN}`;
+  const fibN : number = fibonacci(parseInt(num));
+  let result : string = `fibonacci(${num}) is ${fibN}`;
 
   if (fibN < 0) {
     result = `fibonacci(${num}) is undefined`;


### PR DESCRIPTION
Para corregir errores de la prueba de eslint, se agrego tipificado a varias declaraciones de variables, especificando si son numeros o strings